### PR TITLE
allow for >500 entries by looping through with offsets

### DIFF
--- a/interface-SpeedReport.py
+++ b/interface-SpeedReport.py
@@ -61,20 +61,25 @@ def getToken():
     return token
 
 def getInterfaceStatus(token):
-    url = "https://" + dnac_ip + "/api/v1/interface"
+    url = "https://" + dnac_ip + "/api/v1/interface?offset="
+    offset = 1
     header = {"content-type": "application/json", "X-Auth-Token":token}
-    response = requests.get(url, headers=header, verify=False)
-    if response.status_code != 200:
-        print ("Retrieve Interfaces Status \t\t \033[1;31;40m FAIL \033[0;0m")
-        sys.exit()
-    print ("Retrieve Interfaces Status \t\t \033[1;32;40m PASS \033[0;0m")
-    r_json=response.json()
-    devices = r_json["response"]
     device_list = []
-    i=0
-    for item in devices:
-            i+=1
-            device_list.append([i,item["portName"],item["portMode"],item["interfaceType"],item["status"],item["adminStatus"],item["speed"],item["vlanId"],item["ipv4Address"]])
+    while(True):
+        response = requests.get(url + str(offset), headers=header, verify=False)
+        if response.status_code != 200:
+            print ("Retrieve Interfaces Status \t\t \033[1;31;40m FAIL \033[0;0m")
+            sys.exit()
+        print ("Retrieve Interfaces Status - offset " + str(offset) + " \t\t \033[1;32;40m PASS \033[0;0m")
+        r_json=response.json()
+        devices = r_json["response"]
+        i = 0
+        for item in devices:
+            device_list.append([offset,item["portName"],item["portMode"],item["interfaceType"],item["status"],item["adminStatus"],item["speed"],item["vlanId"],item["ipv4Address"]])
+            offset += 1
+            i += 1
+        if i < 500:
+            break
     table = (tabulate.tabulate(device_list, headers=['Port Name','Port Mode','Interface Type','Oper Status', 'Admin Satus', 'Speed (Kbit/sec)', 'VLAN ID', 'IP Address'],tablefmt="fancy_grid", numalign="center"))
     return table
 


### PR DESCRIPTION
The original example doesn't make any allowances for more than 500 results, which is the maximum single call limit for results. This is unfortunately only enough to allow for approx 10x 48 port switches. 

This code change adds a while loop around the interface API to continue to make calls using the offset until the final result call is less than 500 entries, or the final call is empty in the case of an exact multiple of 500 interfaces.

This should make the report a lot more useful for people as is without complicating it too much as a learning tool for people looking to build on the code (i.e. adding the switch name that the interface is on etc).